### PR TITLE
Refactor and add testing/CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,27 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Format check
+        run: black --check src tests
       - name: Lint
-        run: python -m py_compile src/market_map.py
+        run: flake8 src tests
+      - name: Type check
+        run: mypy src
+      - name: Security check
+        run: bandit -r src -q
+      - name: Test
+        run: pytest --cov=src --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+.mypy_cache/
+.pytest_cache/
+.market_map.png

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Codex Market Map Generator
 
-This repository contains a simple tool for generating one-page market maps from web search results. The main script lives under `src/` and uses [SerpAPI](https://serpapi.com/) to fetch Google results.
+This tool generates a one-page market map image by fetching Google search results and scraping company names from the returned pages. It uses [SerpAPI](https://serpapi.com/) for search and BeautifulSoup for HTML parsing.
 
 ## Setup
 
-1. Install Python dependencies:
+1. Install dependencies
    ```bash
    pip install -r requirements.txt
+   pip install -r requirements-dev.txt  # for development
    ```
-2. Export your SerpAPI key:
+2. Export your SerpAPI key
    ```bash
    export SERPAPI_API_KEY=<your key>
    ```
@@ -21,4 +22,6 @@ Run the script from the repository root:
 python src/market_map.py --max-results 5 "proptech sensor companies"
 ```
 
-The script will print a categorized list of companies and save a `market_map.png` image in the working directory.
+The script prints the categorized companies and creates a `market_map.png` image.
+
+Category keywords can be customised in `src/codex/categories.json`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 88
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+
+[tool.bandit]
+skips = ["B101"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+black
+flake8
+mypy
+bandit
+pytest
+pytest-cov
+requests-mock

--- a/src/codex/categories.json
+++ b/src/codex/categories.json
@@ -1,0 +1,6 @@
+{
+    "Environmental": ["air quality", "climate", "environment"],
+    "Occupancy": ["occupancy", "people counting"],
+    "Energy": ["energy", "hvac"],
+    "Security": ["security", "motion", "safety"]
+}

--- a/src/codex/categorize.py
+++ b/src/codex/categorize.py
@@ -1,0 +1,33 @@
+"""Categorize companies based on keywords."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Set
+
+from .scraper import Company
+
+CONFIG_PATH = Path(__file__).with_name("categories.json")
+
+
+def load_categories(config_path: Path = CONFIG_PATH) -> Dict[str, List[str]]:
+    with config_path.open() as f:
+        return json.load(f)
+
+
+def categorize(
+    companies: Iterable[Company], config: Dict[str, List[str]] | None = None
+) -> Dict[str, Set[str]]:
+    if config is None:
+        config = load_categories()
+    result: Dict[str, Set[str]] = {}
+    for company in companies:
+        lower = company.context.lower()
+        category = "Other"
+        for cat, keywords in config.items():
+            if any(k in lower for k in keywords):
+                category = cat
+                break
+        result.setdefault(category, set()).add(company.name)
+    return result

--- a/src/codex/scraper.py
+++ b/src/codex/scraper.py
@@ -1,0 +1,58 @@
+"""HTML scraping utilities."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import requests
+from bs4 import BeautifulSoup
+
+USER_AGENT = {"User-Agent": "Mozilla/5.0"}
+
+COMPANY_PATTERN = re.compile(r"([A-Z][A-Za-z0-9&-]*(?: [A-Z][A-Za-z0-9&-]*)*)")
+
+
+@dataclass
+class Company:
+    """Represents a company entry."""
+
+    name: str
+    context: str
+
+
+def fetch(url: str) -> str | None:
+    """Fetch a URL and return its text content or ``None`` on error."""
+    try:
+        logging.debug("Fetching %s", url)
+        resp = requests.get(url, headers=USER_AGENT, timeout=10)
+        resp.raise_for_status()
+        return resp.text
+    except Exception as exc:  # noqa: BLE001
+        logging.warning("Failed fetching %s: %s", url, exc)
+        return None
+
+
+def extract_companies(html: str) -> List[Company]:
+    """Extract companies from HTML list elements."""
+    soup = BeautifulSoup(html, "html.parser")
+    lines = [li.get_text(" ", strip=True) for li in soup.find_all("li")]
+    companies: List[Company] = []
+    for line in lines:
+        for match in COMPANY_PATTERN.finditer(line):
+            name = match.group(0)
+            if len(name.split()) <= 4 and not name.isupper():
+                companies.append(Company(name=name, context=line))
+    return companies
+
+
+def scrape_companies(urls: Iterable[str]) -> List[Company]:
+    """Fetch all URLs and extract companies."""
+    all_companies: List[Company] = []
+    for url in urls:
+        html = fetch(url)
+        if html:
+            all_companies.extend(extract_companies(html))
+    return all_companies

--- a/src/codex/search.py
+++ b/src/codex/search.py
@@ -1,0 +1,26 @@
+"""Search utilities using SerpAPI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from serpapi.core import Client
+
+
+@dataclass
+class SearchClient:
+    """Wrapper for SerpAPI search."""
+
+    api_key: str
+
+    def search(self, query: str, max_results: int = 5) -> List[str]:
+        client = Client(api_key=self.api_key)
+        params = {
+            "api_key": self.api_key,
+            "engine": "google",
+            "q": query,
+            "num": max_results,
+        }
+        results = client.search(params)
+        return [r["link"] for r in results.get("organic_results", [])]

--- a/src/codex/visualize.py
+++ b/src/codex/visualize.py
@@ -1,0 +1,28 @@
+"""Visualization utilities to create market map images."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Set
+
+import matplotlib.pyplot as plt
+
+
+def create_market_map(
+    categories: Dict[str, Set[str]], output: str | Path = "market_map.png"
+) -> None:
+    """Render the market map and save to ``output``."""
+    fig, ax = plt.subplots(figsize=(8, 6))
+    y = 0
+    for cat, names in categories.items():
+        ax.text(0.05, 0.9 - y * 0.15, cat, fontsize=12, fontweight="bold")
+        for i, name in enumerate(sorted(names)):
+            ax.text(0.1, 0.88 - (y * 0.15 + i * 0.04), name, fontsize=10)
+        y += 1
+
+    ax.set_axis_off()
+    fig.tight_layout()
+    fig.savefig(str(output))
+    plt.close(fig)
+    logging.info("Market map saved to %s", output)

--- a/src/market_map.py
+++ b/src/market_map.py
@@ -1,124 +1,67 @@
 """Generate a simple market map of companies in a niche sector."""
 
+from __future__ import annotations
+
+import argparse
+import logging
 import os
-import re
-from typing import Iterable, List, Tuple
+from pathlib import Path
 
-import matplotlib.pyplot as plt
-import requests
-from bs4 import BeautifulSoup
-from serpapi.core import Client
-
-USER_AGENT = {"User-Agent": "Mozilla/5.0"}
-
-# API key for SerpAPI is read from the SERPAPI_API_KEY environment variable.
-# The key is intentionally not stored in this repository. Set the variable
-# before running the script or provide it via the ``--api-key`` command-line
-# option.
-SERPAPI_KEY = os.environ.get("SERPAPI_API_KEY")
+from codex.categorize import categorize, load_categories
+from codex.scraper import scrape_companies
+from codex.search import SearchClient
+from codex.visualize import create_market_map
 
 
-def search_results(query: str, max_results: int = 5, api_key: str | None = None) -> List[str]:
-    """Return the first ``max_results`` result links for ``query``."""
-
-    key = api_key or SERPAPI_KEY
+def build_market_map(
+    sector_query: str,
+    max_results: int = 5,
+    api_key: str | None = None,
+    output: str | Path = "market_map.png",
+) -> None:
+    """Fetch company lists and build a market map image."""
+    key = api_key or os.environ.get("SERPAPI_API_KEY")
     if not key:
         raise RuntimeError("SERPAPI_API_KEY environment variable not set")
-
-    params = {
-        "api_key": key,
-        "engine": "google",
-        "q": query,
-        "num": max_results,
-    }
-    client = Client(api_key=key)
-    results = client.search(params)
-    links = []
-    for r in results.get("organic_results", []):
-        links.append(r["link"])
-    return links
-
-
-def extract_companies(url: str) -> List[Tuple[str, str]]:
-    """Scrape company names from a URL's list elements."""
-    try:
-        resp = requests.get(url, headers=USER_AGENT, timeout=10)
-        resp.raise_for_status()
-    except Exception as e:
-        print(f"Failed fetching {url}: {e}")
-        return []
-    soup = BeautifulSoup(resp.text, 'html.parser')
-    lines = [li.get_text(" ", strip=True) for li in soup.find_all('li')]
-    companies = []
-    for line in lines:
-        for match in re.finditer(r'([A-Z][A-Za-z0-9&-]*(?: [A-Z][A-Za-z0-9&-]*)*)', line):
-            name = match.group(0)
-            if len(name.split()) <= 4 and not name.isupper():
-                companies.append((name, line))
-    return companies
-
-
-def categorize(companies: Iterable[Tuple[str, str]]):
-    """Assign each company to a simple category based on keyword heuristics."""
-
-    categories: dict[str, set[str]] = {}
-    for name, text in companies:
-        lower = text.lower()
-        cat = 'Other'
-        if any(k in lower for k in ['air quality', 'climate', 'environment']):
-            cat = 'Environmental'
-        elif any(k in lower for k in ['occupancy', 'people counting']):
-            cat = 'Occupancy'
-        elif 'energy' in lower or 'hvac' in lower:
-            cat = 'Energy'
-        elif any(k in lower for k in ['security', 'motion', 'safety']):
-            cat = 'Security'
-        categories.setdefault(cat, set()).add(name)
-    return categories
-
-
-def create_market_map(categories: dict[str, set[str]], output: str = "market_map.png"):
-    """Render the market map as a PNG image."""
-
-    fig, ax = plt.subplots(figsize=(8, 6))
-    y = 0
-    for cat, names in categories.items():
-        ax.text(0.05, 0.9 - y * 0.15, cat, fontsize=12, fontweight="bold")
-        for i, name in enumerate(sorted(names)):
-            ax.text(0.1, 0.88 - (y * 0.15 + i * 0.04), name, fontsize=10)
-        y += 1
-
-    ax.set_axis_off()
-    fig.tight_layout()
-    fig.savefig(output)
-
-
-def build_market_map(sector_query: str, max_results: int = 5, api_key: str | None = None, output: str = "market_map.png"):
-    """Fetch company lists and build a market map image."""
-
     search_query = f"{sector_query} list"
-    urls = search_results(search_query, max_results=max_results, api_key=api_key)
-    all_companies: List[Tuple[str, str]] = []
-    for url in urls:
-        all_companies.extend(extract_companies(url))
-    categories = categorize(all_companies)
+    search_client = SearchClient(api_key=key)
+    urls = search_client.search(search_query, max_results=max_results)
+    companies = scrape_companies(urls)
+    categories = categorize(companies, load_categories())
     create_market_map(categories, output=output)
-    print(f"Market map saved to {output}")
     for cat, names in categories.items():
-        print(f"\n{cat} ({len(names)} companies):")
+        logging.info("%s (%d companies)", cat, len(names))
         for n in sorted(names):
-            print(" -", n)
+            logging.info(" - %s", n)
 
 
-if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Generate a market map for a given sector")
-    parser.add_argument("query", nargs="*", default=["proptech", "sensor", "companies"], help="sector search terms")
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a market map for a given sector"
+    )
+    parser.add_argument(
+        "query",
+        nargs="*",
+        default=["proptech", "sensor", "companies"],
+        help="sector search terms",
+    )
     parser.add_argument("--api-key", dest="api_key", help="SerpAPI key (optional)")
-    parser.add_argument("--max-results", type=int, default=5, help="number of Google results to parse")
+    parser.add_argument(
+        "--max-results", type=int, default=5, help="number of Google results to parse"
+    )
     parser.add_argument("--output", default="market_map.png", help="output image path")
     args = parser.parse_args()
 
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+
     query_str = " ".join(args.query)
-    build_market_map(query_str, max_results=args.max_results, api_key=args.api_key, output=args.output)
+    build_market_map(
+        query_str,
+        max_results=args.max_results,
+        api_key=args.api_key,
+        output=args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Add src directory to sys.path for tests
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -1,0 +1,8 @@
+from codex.categorize import categorize
+from codex.scraper import Company
+
+
+def test_categorize_environmental():
+    companies = [Company(name="GreenCorp", context="Best air quality sensors")]
+    categories = categorize(companies, {"Environmental": ["air quality"]})
+    assert categories == {"Environmental": {"GreenCorp"}}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+from market_map import build_market_map
+
+
+@patch("codex.search.SearchClient.search")
+@patch("codex.scraper.fetch")
+def test_build_market_map(mock_fetch, mock_search, tmp_path):
+    mock_search.return_value = ["http://example.com"]
+    html = "<ul><li>Gamma Co does energy solutions</li></ul>"
+    mock_fetch.return_value = html
+    out_file = tmp_path / "out.png"
+    build_market_map("gamma", max_results=1, api_key="k", output=out_file)
+    assert out_file.exists()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,15 @@
+from codex.scraper import extract_companies
+
+HTML = """
+<html><body><ul>
+<li>Alpha Corp provides solutions.</li>
+<li>Beta Inc is cool.</li>
+</ul></body></html>
+"""
+
+
+def test_extract_companies_basic():
+    companies = extract_companies(HTML)
+    names = [c.name for c in companies]
+    assert "Alpha Corp" in names
+    assert "Beta Inc" in names

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+from codex.search import SearchClient
+
+
+def test_search_client_parses_links():
+    with patch("codex.search.Client") as mock_cls:
+        instance = mock_cls.return_value
+        instance.search.return_value = {
+            "organic_results": [{"link": "http://example.com"}]
+        }
+        client = SearchClient(api_key="dummy")
+        links = client.search("query")
+        assert links == ["http://example.com"]
+        instance.search.assert_called_once()


### PR DESCRIPTION
## Summary
- reorganize code into package `codex` with search, scrape, categorize and visualize modules
- add dataclass for scraped companies and loadable category config
- implement CLI using new modules with logging
- provide pytest unit and integration tests
- configure Black, Flake8, mypy and Bandit via GitHub Actions
- add developer requirements and project settings

## Testing
- `flake8 src tests`
- `mypy src --config-file pyproject.toml`
- `bandit -r src -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68421d6b71b8832fa63b55370abe52e4